### PR TITLE
Feature/toroidal current

### DIFF
--- a/docs/examples/example_neoclassical.py
+++ b/docs/examples/example_neoclassical.py
@@ -44,6 +44,12 @@ redl_bs = psi_ns * 0.0
 sauter_jdotb = psi_ns * 0.0
 sauter_bs = psi_ns * 0.0
 
+# Toroidal current density and its decomposition
+jphi_total = psi_ns * 0.0
+jphi_bs = psi_ns * 0.0
+jphi_ext = psi_ns * 0.0
+jphi_psdia = psi_ns * 0.0
+
 for i, psi_n in enumerate(psi_ns[1:]):
     try:
         pyro.load_local(psi_n=psi_n, local_geometry="MXH")
@@ -55,6 +61,11 @@ for i, psi_n in enumerate(psi_ns[1:]):
     redl = Redl2021(pyro)
     redl_jdotb[i + 1] = redl.JbsdotB.to("ampere * tesla / cm**2").m
     redl_bs[i + 1] = redl.Jbs.to("ampere / cm**2").m
+
+    jphi_total[i + 1] = redl.Jphi_fsa.to("ampere / cm**2").m
+    jphi_bs[i + 1] = redl.Jphi_bs_fsa.to("ampere / cm**2").m
+    jphi_ext[i + 1] = redl.Jphi_ext_fsa.to("ampere / cm**2").m
+    jphi_psdia[i + 1] = redl.Jphi_psdia_fsa.to("ampere / cm**2").m
 
     sauter = Sauter1999(pyro)
     sauter_jdotb[i + 1] = sauter.JbsdotB.to("ampere * tesla / cm**2").m
@@ -92,6 +103,27 @@ plt.plot(transp_psi_ns, bs_sauter_transp, label="SAUTER (1999) TRANSP")
 plt.plot(psi_ns, redl_bs, ls="--", lw=2, label="Redl (2021) Pyro")
 plt.plot(psi_ns, sauter_bs, ls="--", lw=2, label="Sauter (1999) Pyro")
 plt.title(r"$\frac{\langle J_{bs} \cdot B\rangle}{\langle B^2\rangle^{1/2}}$")
+plt.xlabel(r"$\psi_N$")
+plt.ylabel(r"$A cm^{-2}$")
+plt.grid()
+plt.legend()
+plt.show()
+
+# Decomposition of the toroidal current density. Note the external contribution
+# is auxiliary + ohmic combined, as a local calculation cannot separate them.
+plt.plot(psi_ns, jphi_total, lw=2, color="k", label="Total")
+plt.plot(psi_ns, jphi_bs, ls="--", lw=2, label="Bootstrap")
+plt.plot(psi_ns, jphi_ext, ls="--", lw=2, label="External (auxiliary + ohmic)")
+plt.plot(psi_ns, jphi_psdia, ls="--", lw=2, label="Pfirsch-Schluter + diamagnetic")
+plt.plot(
+    psi_ns,
+    jphi_bs + jphi_ext + jphi_psdia,
+    ls=":",
+    lw=2,
+    color="C3",
+    label="Sum of components",
+)
+plt.title(r"$\langle J_\phi \rangle$ (Redl 2021)")
 plt.xlabel(r"$\psi_N$")
 plt.ylabel(r"$A cm^{-2}$")
 plt.grid()

--- a/docs/examples/example_neoclassical.py
+++ b/docs/examples/example_neoclassical.py
@@ -3,7 +3,11 @@ import netCDF4 as nc
 import numpy as np
 
 from pyrokinetics import Pyro, template_dir
-from pyrokinetics.diagnostics.neoclassical import Redl2021, Sauter1999
+from pyrokinetics.diagnostics.neoclassical import (
+    Redl2021,
+    Sauter1999,
+    integrate_toroidal_current,
+)
 
 # Equilibrium and Kinetics data file
 transp_cdf = template_dir / "transp.cdf"
@@ -18,7 +22,10 @@ time_index = np.argmin(np.abs(time - t_interest))
 psi = data["PLFLX"][time_index, :]
 transp_psi_ns = psi / psi[-1]
 
-downsize = 1
+# Take every downsize'th flux surface. The cost of this example is dominated by
+# the MXH fit in load_local (~1.6 s per surface), not by the current
+# calculation (~0.1 s), so thinning the radial grid is what makes it faster.
+downsize = 2
 psi_ns = transp_psi_ns[::downsize]
 
 bs_sauter_transp = data["CURBSSAU0"][time_index, :]
@@ -44,19 +51,39 @@ redl_bs = psi_ns * 0.0
 sauter_jdotb = psi_ns * 0.0
 sauter_bs = psi_ns * 0.0
 
-# Toroidal current density and its decomposition
+# Toroidal current density and its decomposition, in both conventions:
+# <J_phi> is the plain flux surface average, J_phi^eff is the effective density
+# (1 / 2 pi rho) dIp/drho. They differ by roughly the elongation.
 jphi_total = psi_ns * 0.0
 jphi_bs = psi_ns * 0.0
 jphi_ext = psi_ns * 0.0
 jphi_psdia = psi_ns * 0.0
+
+jphi_eff_total = psi_ns * 0.0
+jphi_eff_bs = psi_ns * 0.0
+jphi_eff_ext = psi_ns * 0.0
+jphi_eff_psdia = psi_ns * 0.0
+
+# Print every current component on each surface. The external contribution is
+# auxiliary + ohmic combined, since a local calculation cannot separate them.
+print("\nCurrent components on each flux surface (Redl 2021)\n")
+print(
+    f"{'psi_n':>6} | {'<J.B>':>10} {'<Jbs.B>':>10} {'<Jext.B>':>10} |"
+    f" {'<Jphi>':>9} {'bs':>9} {'ext':>9} {'ps+dia':>9} |"
+    f" {'Jphi_eff':>9} | {'Ip':>7}"
+)
+print(
+    f"{'':>6} | {'A T/cm2':>10} {'A T/cm2':>10} {'A T/cm2':>10} |"
+    f" {'A/cm2':>9} {'A/cm2':>9} {'A/cm2':>9} {'A/cm2':>9} |"
+    f" {'A/cm2':>9} | {'MA':>7}"
+)
+print("-" * 104)
 
 for i, psi_n in enumerate(psi_ns[1:]):
     try:
         pyro.load_local(psi_n=psi_n, local_geometry="MXH")
     except Exception:
         continue
-
-    pyro.load_local(psi_n=psi_n, local_geometry="MXH")
 
     redl = Redl2021(pyro)
     redl_jdotb[i + 1] = redl.JbsdotB.to("ampere * tesla / cm**2").m
@@ -67,9 +94,64 @@ for i, psi_n in enumerate(psi_ns[1:]):
     jphi_ext[i + 1] = redl.Jphi_ext_fsa.to("ampere / cm**2").m
     jphi_psdia[i + 1] = redl.Jphi_psdia_fsa.to("ampere / cm**2").m
 
+    jphi_eff_total[i + 1] = redl.Jphi_eff.to("ampere / cm**2").m
+    jphi_eff_bs[i + 1] = redl.Jphi_bs_eff.to("ampere / cm**2").m
+    jphi_eff_ext[i + 1] = redl.Jphi_ext_eff.to("ampere / cm**2").m
+    jphi_eff_psdia[i + 1] = redl.Jphi_psdia_eff.to("ampere / cm**2").m
+
+    parallel_units = "ampere * tesla / cm**2"
+    print(
+        f"{psi_n:6.3f} |"
+        f" {redl.JdotB.to(parallel_units).m:10.4g}"
+        f" {redl.JbsdotB.to(parallel_units).m:10.4g}"
+        f" {redl.JextdotB.to(parallel_units).m:10.4g} |"
+        f" {jphi_total[i + 1]:9.4g}"
+        f" {jphi_bs[i + 1]:9.4g}"
+        f" {jphi_ext[i + 1]:9.4g}"
+        f" {jphi_psdia[i + 1]:9.4g} |"
+        f" {jphi_eff_total[i + 1]:9.4g} |"
+        f" {redl.Ip.to('MA').m:7.3f}"
+    )
+
     sauter = Sauter1999(pyro)
     sauter_jdotb[i + 1] = sauter.JbsdotB.to("ampere * tesla / cm**2").m
     sauter_bs[i + 1] = sauter.Jbs.to("ampere / cm**2").m
+
+# Radially integrate each component to get the total current it carries. This
+# repeats the flux surface scan, so it is the slow part of this example.
+#
+# Restrict the scan to surfaces where the model is trustworthy:
+#  - near the axis the inverse aspect ratio tends to zero and the trapped
+#    fraction degenerates (on this equilibrium it goes negative at psi_n = 0.0009,
+#    which makes the bootstrap current NaN)
+#  - near the separatrix the MXH fit degrades, and the last rows of the table
+#    above flip sign and blow up
+# Either would quietly corrupt the integral, so exclude both.
+psi_n_min, psi_n_max = 0.01, 0.95
+psi_n_all = np.asarray(psi_ns)
+psi_n_scan = psi_n_all[(psi_n_all > psi_n_min) & (psi_n_all < psi_n_max)]
+integrated = integrate_toroidal_current(pyro, psi_n_scan, local_geometry="MXH")
+
+total = integrated["Ip"][-1].to("MA")
+rho_edge = integrated["rho"][-1].to("m")
+print(
+    f"\nTotal current carried by each component, integrated over "
+    f"psi_n = {psi_n_min} to {psi_n_max}\n"
+)
+for label, key in [
+    ("bootstrap", "Ip_bs"),
+    ("external (auxiliary + ohmic)", "Ip_ext"),
+    ("Pfirsch-Schluter + diamagnetic", "Ip_psdia"),
+]:
+    current = integrated[key][-1].to("MA")
+    print(f"  {label:<32} {current.m:8.4f} MA  ({100 * current.m / total.m:5.1f} %)")
+
+print(f"  {'total':<32} {total.m:8.4f} MA")
+print(
+    f"  {'Ampere law, same surface':<32} "
+    f"{integrated['Ip_ampere'][-1].to('MA').m:8.4f} MA   (independent check)"
+)
+print(f"\n  outermost surface integrated: rho = {rho_edge.m:.3f} m")
 
 
 plt.plot(transp_psi_ns, jdotb_nclass, lw=2, label="NCLASS TRANSP")
@@ -124,6 +206,39 @@ plt.plot(
     label="Sum of components",
 )
 plt.title(r"$\langle J_\phi \rangle$ (Redl 2021)")
+plt.xlabel(r"$\psi_N$")
+plt.ylabel(r"$A cm^{-2}$")
+plt.grid()
+plt.legend()
+plt.show()
+
+# The same decomposition for the effective toroidal current density,
+# J_phi^eff = (1 / 2 pi rho) dIp/drho. This is the definition whose 2 pi rho
+# weighted radial integral gives the enclosed plasma current, so these are the
+# components that integrate to the totals printed above.
+plt.plot(psi_ns, jphi_eff_total, lw=2, color="k", label="Total")
+plt.plot(psi_ns, jphi_eff_bs, ls="--", lw=2, label="Bootstrap")
+plt.plot(psi_ns, jphi_eff_ext, ls="--", lw=2, label="External (auxiliary + ohmic)")
+plt.plot(psi_ns, jphi_eff_psdia, ls="--", lw=2, label="Pfirsch-Schluter + diamagnetic")
+plt.plot(
+    psi_ns,
+    jphi_eff_bs + jphi_eff_ext + jphi_eff_psdia,
+    ls=":",
+    lw=2,
+    color="C3",
+    label="Sum of components",
+)
+plt.title(r"$J_\phi^{eff} = \frac{1}{2\pi\rho}\frac{dI_p}{d\rho}$ (Redl 2021)")
+plt.xlabel(r"$\psi_N$")
+plt.ylabel(r"$A cm^{-2}$")
+plt.grid()
+plt.legend()
+plt.show()
+
+# Both conventions side by side, showing they differ by roughly the elongation
+plt.plot(psi_ns, jphi_total, lw=2, color="k", label=r"$\langle J_\phi \rangle$")
+plt.plot(psi_ns, jphi_eff_total, ls="--", lw=2, color="C0", label=r"$J_\phi^{eff}$")
+plt.title(r"Toroidal current density: the two conventions")
 plt.xlabel(r"$\psi_N$")
 plt.ylabel(r"$A cm^{-2}$")
 plt.grid()

--- a/src/pyrokinetics/diagnostics/neoclassical.py
+++ b/src/pyrokinetics/diagnostics/neoclassical.py
@@ -1,10 +1,10 @@
 import numpy as np
 from pint.errors import DimensionalityError
-from scipy.integrate import simpson
+from scipy.integrate import cumulative_trapezoid, simpson
 
 from ..decorators import not_implemented
 from ..pyro import Pyro
-from ..units import PyroContextError
+from ..units import PyroContextError, ureg
 
 
 class BootstrapModel:
@@ -42,7 +42,26 @@ class BootstrapModel:
         # Get total current
         self.get_total_current()
 
-    def get_total_current(self):
+        # Get toroidal current
+        self.get_toroidal_current()
+
+    def _get_grad_shafranov_terms(self):
+        r"""
+        Common Grad-Shafranov terms shared by the current calculations
+
+        Returns
+        -------
+        dpsidr : Float
+            :math:`\partial \psi / \partial r`, signed by ``ip_ccw``
+        F : Float
+            Current function :math:`F = R B_\zeta`, signed by ``bt_ccw``
+        Fprime : Float
+            :math:`\partial F / \partial \psi`
+        mu0_dpdpsi : Float
+            :math:`\mu_0 \partial p / \partial \psi`
+        mu0 : Float
+            :math:`\mu_0` in the normalised units of the current context
+        """
 
         metric = self.pyro.metric_terms
         dpsidr = metric.dpsidr * -self.ip_ccw
@@ -60,27 +79,142 @@ class BootstrapModel:
         B0 = 1 * self.B2_fsa.units**0.5
         mu0 = B0**2 * beta / (2 * self.pe)
 
+        return dpsidr, F, Fprime, mu0_dpdpsi, mu0
+
+    def get_total_current(self):
+        r"""
+        Total parallel current moment :math:`\langle J \cdot B \rangle` from the
+        Grad-Shafranov equation, and the external (non-bootstrap) remainder
+
+        .. math::
+            \langle J \cdot B \rangle =
+                \frac{F' \langle B^2 \rangle}{\mu_0} + F \frac{\partial p}{\partial \psi}
+        """
+
+        _, F, Fprime, mu0_dpdpsi, mu0 = self._get_grad_shafranov_terms()
+
         self.JdotB = (Fprime * self.B2_fsa + F * mu0_dpdpsi) / mu0
         self.JextdotB = self.JdotB - self.JbsdotB
 
     def get_Fprime_from_total_current(self, JdotB=None):
+        r"""
+        Invert :func:`get_total_current` to obtain :math:`F'` from a given
+        :math:`\langle J \cdot B \rangle`
+        """
 
-        metric = self.pyro.metric_terms
-        dpsidr = metric.dpsidr * -self.ip_ccw
-        mu0_dpdr = metric.mu0dPdr
-        mu0_dpdpsi = mu0_dpdr / dpsidr
-
-        F = metric.B_zeta * self.bt_ccw
-
-        try:
-            beta = self.pyro.numerics.beta.m
-        except AttributeError:
-            beta = self.pyro.norms.beta.m
-
-        B0 = 1 * self.B2_fsa.units**0.5
-        mu0 = B0**2 * beta / (2 * self.pe)
+        _, F, _, mu0_dpdpsi, mu0 = self._get_grad_shafranov_terms()
 
         return (JdotB * mu0 - F * mu0_dpdpsi) / self.B2_fsa
+
+    def get_toroidal_current(self):
+        r"""
+        Toroidal current density, decomposed into bootstrap, external and combined
+        Pfirsch-Schlüter + diamagnetic contributions.
+
+        The local toroidal current density follows from the Grad-Shafranov equation:
+
+        .. math::
+            J_\phi(\theta) = R \frac{\partial p}{\partial \psi}
+                           + \frac{F F'}{\mu_0 R}
+
+        Two flux-surface reductions of :math:`J_\phi` are provided, since they are
+        **not** the same quantity (they differ by roughly the elongation):
+
+        - ``Jphi_fsa``: the plain flux-surface average :math:`\langle J_\phi \rangle`.
+          This is the quantity transport codes such as SCENE, JETTO and TRANSP
+          report as their toroidal current density.
+        - ``Jphi_eff``: the effective toroidal current density
+          :math:`J_\phi^{\rm eff} = \frac{1}{2 \pi \rho} \frac{\partial I_p}{\partial \rho}
+          = \frac{V'}{4 \pi^2 \rho} \langle J_\phi / R \rangle`, i.e. the current density
+          of an equivalent circular cross-section of radius :math:`\rho`.
+
+        Each is split into three parts. Parallel driven currents (bootstrap and
+        external) contribute
+
+        .. math::
+            J_\phi^{d} = \frac{F \langle J^d_\parallel \cdot B \rangle}{\langle B^2 \rangle}
+                         \langle 1/R \rangle
+
+        for ``Jphi_fsa``, and the analogous form with
+        :math:`\frac{V'}{4 \pi^2 \rho} \langle R^{-2} \rangle` for ``Jphi_eff``. The
+        remaining Pfirsch-Schlüter and diamagnetic currents are grouped together.
+
+        Notes
+        -----
+        The external contribution is **auxiliary plus ohmic combined**. A local
+        calculation cannot separate them, since ``JextdotB`` is obtained by
+        subtracting the bootstrap current from the total.
+
+        ``get_bs_current`` takes the absolute value of ``JbsdotB``, so ``JextdotB``
+        and the external toroidal contributions derived from it are only correct
+        when :math:`\langle J \cdot B \rangle` is positive in the sign convention
+        of the equilibrium.
+
+        Sets ``Jphi``, ``Jphi_fsa``, ``Jphi_bs_fsa``, ``Jphi_ext_fsa``,
+        ``Jphi_psdia_fsa``, ``Jphi_eff``, ``Jphi_bs_eff``, ``Jphi_ext_eff``,
+        ``Jphi_psdia_eff`` and ``Ip``.
+        """
+
+        metric = self.pyro.metric_terms
+
+        dpsidr, F, Fprime, mu0_dpdpsi, mu0 = self._get_grad_shafranov_terms()
+
+        # dp/dpsi
+        dpdpsi = mu0_dpdpsi / mu0
+
+        # Flux surface averages of the geometry
+        R_fsa = metric.flux_surface_average(metric.R)
+        R_inv_fsa = metric.flux_surface_average(1.0 / metric.R)
+        R_inv2_fsa = metric.flux_surface_average(1.0 / metric.R**2)
+
+        Vprime = metric.dVdr
+        rho = metric.rho
+
+        # Local toroidal current density from the Grad-Shafranov equation
+        self.Jphi = metric.R * dpdpsi + F * Fprime / (mu0 * metric.R)
+
+        # --- Flux-surface averaged toroidal current density, <J_phi> ---
+        self.Jphi_fsa = R_fsa * dpdpsi + F * Fprime * R_inv_fsa / mu0
+
+        # Parallel driven currents, <J_d . B> F <1/R> / <B^2>
+        parallel_factor = F * R_inv_fsa / self.B2_fsa
+        self.Jphi_bs_fsa = parallel_factor * self.JbsdotB
+        self.Jphi_ext_fsa = parallel_factor * self.JextdotB
+
+        # Combined Pfirsch-Schlüter and diamagnetic contribution
+        self.Jphi_psdia_fsa = dpdpsi * (R_fsa - F**2 * R_inv_fsa / self.B2_fsa)
+
+        # --- Effective toroidal current density, (1 / 2 pi rho) dIp/drho ---
+        eff_factor = Vprime / (4 * np.pi**2 * rho)
+        self.Jphi_eff = eff_factor * (dpdpsi + F * Fprime * R_inv2_fsa / mu0)
+
+        parallel_factor_eff = eff_factor * F * R_inv2_fsa / self.B2_fsa
+        self.Jphi_bs_eff = parallel_factor_eff * self.JbsdotB
+        self.Jphi_ext_eff = parallel_factor_eff * self.JextdotB
+
+        self.Jphi_psdia_eff = (
+            eff_factor * dpdpsi * (1.0 - F**2 * R_inv2_fsa / self.B2_fsa)
+        )
+
+        # --- Radial derivative of the enclosed current, dIp/drho = 2 pi rho J_eff ---
+        # Integrating these over rho gives the total current carried by each
+        # component, see ``integrate_toroidal_current``
+        self.dIp_drho = 2 * np.pi * rho * self.Jphi_eff
+        self.dIp_bs_drho = 2 * np.pi * rho * self.Jphi_bs_eff
+        self.dIp_ext_drho = 2 * np.pi * rho * self.Jphi_ext_eff
+        self.dIp_psdia_drho = 2 * np.pi * rho * self.Jphi_psdia_eff
+
+        # --- Total toroidal current enclosed by this flux surface ---
+        # mu0 Ip = V' psi' <|grad rho|^2 / R^2> / (4 pi^2), using V' = 2 pi int(J dtheta)
+        # and psi' = 2 pi dpsidr. The leading minus sign puts Ip in the same sign
+        # convention as Jphi above, so that Ip = int(Jphi_eff 2 pi rho drho).
+        grad_r2 = metric.toroidal_contravariant_metric("r", "r")
+        self.Ip = (
+            -dpsidr
+            * Vprime
+            * metric.flux_surface_average(grad_r2 / metric.R**2)
+            / (2 * np.pi * mu0)
+        )
 
     def get_trapped_fraction(self):
 
@@ -91,10 +225,8 @@ class BootstrapModel:
         B_mod = abs(metric.B_magnitude)
         B_max = np.max(B_mod)
 
-        B2_fsa = simpson(B_mod.m**2 * Jacobian.m, x=theta) / simpson(
-            Jacobian.m, x=theta
-        )
-        B2_fsa_units = B2_fsa * B_mod.units**2
+        B2_fsa_units = metric.flux_surface_average(B_mod**2)
+        B2_fsa = B2_fsa_units.m
 
         lambd_grid = np.linspace(0, 1 / B_max, 100)
         lambd = np.tile(lambd_grid, (ntheta, 1))
@@ -653,3 +785,122 @@ class Sauter1999(BootstrapModel):
         # )
 
         self.Jbs = self.JbsdotB / np.sqrt(self.B2_fsa)
+
+
+def integrate_toroidal_current(pyro, psi_n, model=Redl2021, ntheta=None, **kwargs):
+    r"""
+    Total toroidal current carried by each component, integrated over the poloidal
+    cross-section of a set of flux surfaces.
+
+    A ``BootstrapModel`` describes a single flux surface, so the current enclosed by
+    each component cannot be obtained locally -- it requires a radial scan. This
+    function loops over ``psi_n``, builds ``model`` on each surface, and cumulatively
+    integrates
+
+    .. math::
+        I^d_p(\rho) = \int_0^{\rho} 2 \pi \rho' J^{d,\rm eff}_\phi \, d\rho'
+
+    for each of the bootstrap, external and Pfirsch-Schlueter + diamagnetic parts.
+
+    Notes
+    -----
+    There is only one set of total currents, and it follows from the ``Jphi_*_eff``
+    densities. ``Jphi_eff`` is *defined* as
+    :math:`\frac{1}{2 \pi \rho} \partial I_p / \partial \rho`, so its
+    :math:`2 \pi \rho` weighted integral is the enclosed current by construction.
+    ``Jphi_fsa`` is a reporting convention (it is what SCENE, JETTO and TRANSP call
+    their toroidal current density) but it is volume weighted, so integrating it over
+    the poloidal area does **not** give the plasma current -- for a strongly shaped
+    equilibrium that route is wrong by tens of percent.
+
+    The innermost surface contributes :math:`\pi \rho_0^2 J^{\rm eff}_\phi(\rho_0)`,
+    i.e. the current density is taken as constant between the magnetic axis and the
+    first surface. Start the scan close to the axis to keep this small.
+
+    Parameters
+    ----------
+    pyro : Pyro
+        Pyro object with a global equilibrium and kinetics loaded
+    psi_n : ArrayLike
+        Normalised poloidal flux values to scan over, in increasing order
+    model : type, default ``Redl2021``
+        ``BootstrapModel`` subclass to use
+    ntheta : int, optional
+        Number of theta points passed to the model
+    **kwargs
+        Additional keyword arguments passed to ``pyro.load_local``, for example
+        ``local_geometry="MXH"``
+
+    Returns
+    -------
+    dict
+        Dictionary of arrays over the surfaces that loaded successfully, with keys
+        ``psi_n``, ``rho`` [metre], ``Ip_bs``, ``Ip_ext``, ``Ip_psdia``, ``Ip`` (the
+        sum of the three components) and ``Ip_ampere`` (the enclosed current obtained
+        locally from Ampere's law on each surface, as an independent check), all in
+        amperes.
+
+        Results are returned in physical units rather than normalised ones, because
+        the normalisation references (``nref``, ``tref``, ``bref``) differ from one
+        flux surface to the next and so cannot label a radial profile.
+    """
+
+    psi_n = np.asarray(psi_n)
+
+    psi_n_ok = []
+    rho = []
+    dIp_drho = {"bs": [], "ext": [], "psdia": []}
+    Ip_ampere = []
+
+    for psi in psi_n:
+        try:
+            pyro.load_local(psi_n=psi, **kwargs)
+        except Exception:
+            continue
+
+        bootstrap = model(pyro, ntheta=ntheta)
+
+        # Convert to physical units here, inside the loop. The reference values
+        # behind the normalised units (nref, tref, bref) are those of the flux
+        # surface currently loaded, and are overwritten by the next load_local
+        # call -- so a normalised quantity kept across surfaces would later be
+        # converted using the wrong references.
+        psi_n_ok.append(psi)
+        rho.append(pyro.metric_terms.rho.to("meter").m)
+        dIp_drho["bs"].append(bootstrap.dIp_bs_drho.to("ampere / meter").m)
+        dIp_drho["ext"].append(bootstrap.dIp_ext_drho.to("ampere / meter").m)
+        dIp_drho["psdia"].append(bootstrap.dIp_psdia_drho.to("ampere / meter").m)
+        Ip_ampere.append(bootstrap.Ip.to("ampere").m)
+
+    if len(rho) < 2:
+        raise RuntimeError(
+            "Need at least two flux surfaces to integrate the toroidal current, "
+            f"but only {len(rho)} of {len(psi_n)} loaded successfully"
+        )
+
+    rho = np.array(rho) * ureg.meter
+
+    result = {
+        "psi_n": np.array(psi_n_ok),
+        "rho": rho,
+        "Ip_ampere": np.array(Ip_ampere) * ureg.ampere,
+    }
+
+    total = None
+    for name, values in dIp_drho.items():
+        derivative = np.array(values) * ureg.ampere / ureg.meter
+
+        # Contribution from the axis up to the first surface, assuming a constant
+        # current density there: int_0^rho0 2 pi rho J drho = rho0 / 2 * dIp/drho
+        axis = 0.5 * rho[0] * derivative[0]
+
+        integral = (
+            cumulative_trapezoid(derivative.m, rho.m, initial=0.0) * ureg.ampere + axis
+        )
+
+        result[f"Ip_{name}"] = integral
+        total = integral if total is None else total + integral
+
+    result["Ip"] = total
+
+    return result

--- a/src/pyrokinetics/local_geometry/metric.py
+++ b/src/pyrokinetics/local_geometry/metric.py
@@ -359,10 +359,17 @@ class MetricTerms:  # CleverDict
             V' = \frac{\partial V}{\partial r}
                = 2\pi \oint \mathcal{J} d\theta
 
-        Uses the same quadrature as :func:`flux_surface_average`, so that identities
-        combining :math:`V'` with flux-surface averages hold to machine precision.
-        ``LocalGeometry.get_flux_surface_area_volume_derivatives`` computes the same
-        quantity with an adaptive quadrature on the fitted surface.
+        The :math:`\theta` integral is normalised by ``theta_range`` so that the
+        result is independent of how many poloidal turns the grid spans, in the
+        same way as :attr:`Y` and the :math:`\partial B_\zeta / \partial r` terms.
+
+        ``LocalGeometry.get_flux_surface_area_volume_derivatives`` returns this same
+        quantity as its third element, integrating the identical Jacobian with an
+        adaptive quadrature over the fitted surface. This property is kept because
+        it is roughly three orders of magnitude cheaper -- it reuses the Jacobian
+        already evaluated on the :math:`\theta` grid, whereas the ``LocalGeometry``
+        routine runs three adaptive quadratures and discards two of the results.
+        The two are cross-checked in ``test_dVdr_matches_local_geometry``.
 
         Returns
         -------
@@ -371,9 +378,10 @@ class MetricTerms:  # CleverDict
         """
 
         return (
-            2
-            * np.pi
+            4
+            * np.pi**2
             * simpson(self.Jacobian.m, x=self.regulartheta)
+            / self.theta_range
             * self.Jacobian.units
         )
 

--- a/src/pyrokinetics/local_geometry/metric.py
+++ b/src/pyrokinetics/local_geometry/metric.py
@@ -1,5 +1,6 @@
 import numpy as np
 import scipy.integrate as integrate
+from scipy.integrate import simpson
 from scipy.interpolate import interp1d
 
 from ..units import ureg
@@ -310,6 +311,71 @@ class MetricTerms:  # CleverDict
             index2 = np.argwhere(self.field_coords == coord2)
 
         return self._field_aligned_contravariant_metric[index1, index2][0][0]
+
+    def flux_surface_average(self, quantity):
+        r"""
+        Flux-surface average of a quantity defined on ``regulartheta``
+
+        .. math::
+            \langle A \rangle = \frac{\oint A \mathcal{J} d\theta}
+                                     {\oint \mathcal{J} d\theta}
+
+        where :math:`\mathcal{J}` is the Jacobian of the flux surface. This is the
+        standard :math:`dV`-weighted average, since :math:`dV = \mathcal{J}\,dr\,
+        d\theta\,d\zeta`.
+
+        Parameters
+        ----------
+        quantity : ArrayLike
+            Quantity to average, defined on the same :math:`\theta` grid as
+            ``regulartheta``. May be a plain array or a ``pint`` quantity; units
+            are preserved.
+
+        Returns
+        -------
+        Float
+            Flux-surface average of ``quantity``, with the same units as the input
+        """
+
+        jacobian = self.Jacobian.m
+
+        # scipy cannot integrate pint quantities, so strip units explicitly and
+        # re-attach them afterwards (UnitStrippedWarning is an error project-wide)
+        units = getattr(quantity, "units", None)
+        magnitude = quantity.m if units is not None else np.asarray(quantity)
+
+        average = simpson(magnitude * jacobian, x=self.regulartheta) / simpson(
+            jacobian, x=self.regulartheta
+        )
+
+        return average * units if units is not None else average
+
+    @property
+    def dVdr(self):
+        r"""
+        Derivative of the flux surface volume with respect to :math:`r`
+
+        .. math::
+            V' = \frac{\partial V}{\partial r}
+               = 2\pi \oint \mathcal{J} d\theta
+
+        Uses the same quadrature as :func:`flux_surface_average`, so that identities
+        combining :math:`V'` with flux-surface averages hold to machine precision.
+        ``LocalGeometry.get_flux_surface_area_volume_derivatives`` computes the same
+        quantity with an adaptive quadrature on the fitted surface.
+
+        Returns
+        -------
+        Float, units [lref**2]
+            :math:`\partial V / \partial r`
+        """
+
+        return (
+            2
+            * np.pi
+            * simpson(self.Jacobian.m, x=self.regulartheta)
+            * self.Jacobian.units
+        )
 
     @property
     def B_zeta(self):

--- a/src/pyrokinetics/local_species.py
+++ b/src/pyrokinetics/local_species.py
@@ -369,6 +369,7 @@ class LocalSpecies(CleverDict):
         keep_base_species_z: bool = False,
         keep_base_species_mass: bool = False,
         update_zeff: bool = False,
+        update_nu: bool = False,
     ) -> None:
         r"""
         Merge multiple species into one. Performs a weighted average depending on the
@@ -410,6 +411,30 @@ class LocalSpecies(CleverDict):
             scatter in the experiment, so for those models the cached value remains
             the physical one. Set ``update_zeff=True`` when you want a
             self-consistent single-ion plasma instead.
+        update_nu: bool, default False
+            Whether to rescale the base species' collision frequency ``nu`` to match
+            its post-merge charge, density and mass.
+
+            ``nu`` is a *like-species* frequency,
+            :math:`\nu_s \propto z_s^4 n_s / (T_s^{3/2} \sqrt{m_s})`, set once by
+            :func:`from_kinetics` (or read from a gyrokinetic input file) and not
+            otherwise derived. By default the merge leaves it untouched, so the base
+            species keeps a ``nu`` belonging to its pre-merge density -- which is
+            inconsistent with the ``dens`` written alongside it. Pass ``True`` to
+            rescale it by the factor the merge implies.
+
+            The value is rescaled, not recomputed from scratch, so the Coulomb
+            logarithm and unit convention already carried by ``nu`` survive. That
+            matters because ``nu`` need not have come from ``from_kinetics`` at all:
+            for a ``LocalSpecies`` read from a gyrokinetic input file it is whatever
+            that file specified, and rebuilding it would silently substitute
+            pyrokinetics' own Coulomb logarithm -- which cannot even be evaluated
+            without physical densities and temperatures.
+
+            The default is ``False`` for backwards compatibility. Note that neither
+            setting reproduces the real main-ion collisionality: collisions against
+            the full ion mix go as :math:`Z^2 n_e Z_{\rm eff}`, which a single merged
+            species cannot represent. See also ``update_zeff``.
 
         Raises
         ------
@@ -456,10 +481,25 @@ class LocalSpecies(CleverDict):
                 / new_dens
             )
 
+        # collision frequency, rescaled rather than rebuilt so that whatever Coulomb
+        # logarithm and unit convention are already baked into ``nu`` are preserved.
+        # nu ~ z^4 dens / (temp^1.5 sqrt(mass)), and temp is unchanged by the merge.
+        if update_nu:
+            base = self[base_species]
+            new_nu = (
+                base.nu
+                * (new_z / base.z) ** 4
+                * (new_dens / base.dens)
+                * np.sqrt(base.mass / new_mass)
+            )
+
         self[base_species].dens = new_dens
         self[base_species].z = new_z
         self[base_species].inverse_ln = new_inverse_ln
         self[base_species].mass = new_mass
+
+        if update_nu:
+            self[base_species].nu = new_nu
 
         merge_species.remove(base_species)
 

--- a/src/pyrokinetics/local_species.py
+++ b/src/pyrokinetics/local_species.py
@@ -368,8 +368,9 @@ class LocalSpecies(CleverDict):
         merge_species: Iterable[str],
         keep_base_species_z: bool = False,
         keep_base_species_mass: bool = False,
+        update_zeff: bool = False,
     ) -> None:
-        """
+        r"""
         Merge multiple species into one. Performs a weighted average depending on the
         densities of each species to preserve quasineutrality.
 
@@ -387,6 +388,28 @@ class LocalSpecies(CleverDict):
             Mass of new species
                 True keeps base_species mass
                 False/None results in a density-weighted average
+        update_zeff: bool, default False
+            Whether to recalculate ``zeff`` from the species remaining after the merge.
+
+            ``zeff`` is *not* derived on demand: it is set once by
+            :func:`from_kinetics` and then cached. By default a merge leaves that
+            cached value untouched, so ``zeff`` continues to describe the original
+            multi-species plasma even though the species carrying the impurity charge
+            have gone. Pass ``True`` to make ``zeff`` consistent with the species
+            actually present.
+
+            The default is ``False`` for backwards compatibility, and because the
+            stale value is often the one you want. Consumers such as
+            :class:`~pyrokinetics.diagnostics.neoclassical.Redl2021` and
+            :class:`~pyrokinetics.diagnostics.neoclassical.Sauter1999` treat
+            :math:`Z_{\rm eff}` as an *independent* key parameter describing
+            electron-ion pitch-angle scattering in the real plasma, alongside the
+            trapped fraction and collisionality -- not as a property of whichever
+            species list is being carried. Merging impurities into a hydrogenic
+            species for a gyrokinetic run does not change how strongly electrons
+            scatter in the experiment, so for those models the cached value remains
+            the physical one. Set ``update_zeff=True`` when you want a
+            self-consistent single-ion plasma instead.
 
         Raises
         ------
@@ -441,6 +464,10 @@ class LocalSpecies(CleverDict):
         merge_species.remove(base_species)
 
         self.remove_species(*merge_species)
+
+        if update_zeff:
+            self.set_zeff()
+
         self.update_pressure()
         self.check_quasineutrality()
 

--- a/tests/diagnostics/test_neoclassical.py
+++ b/tests/diagnostics/test_neoclassical.py
@@ -173,3 +173,47 @@ def test_integrate_toroidal_current():
 
     # Integrating outwards, the enclosed current grows monotonically in magnitude
     assert np.all(np.diff(np.abs(result["Ip"].m)) > 0)
+
+
+def test_Fprime_from_total_current_round_trip():
+    """
+    get_Fprime_from_total_current inverts the Grad-Shafranov relation that
+    get_total_current uses, both for the equilibrium <J.B> and for a modified
+    one (the workflow in docs/examples/example_modify_shear.py).
+    """
+
+    pyro = Pyro(
+        eq_file=template_dir / "step.geqdsk",
+        eq_type="GEQDSK",
+        kinetics_file=template_dir / "scene.cdf",
+        kinetics_type="SCENE",
+    )
+
+    for psi_n in [0.3, 0.5, 0.7]:
+        pyro.load_local(psi_n=psi_n, local_geometry="MXH")
+
+        redl = Redl2021(pyro)
+        metric = pyro.metric_terms
+
+        # The F' that get_total_current used to build <J.B> must come back out
+        dpsidr = metric.dpsidr * -redl.ip_ccw
+        expected = metric.dB_zeta_dr / dpsidr * redl.bt_ccw
+
+        recovered = redl.get_Fprime_from_total_current(redl.JdotB)
+        assert_allclose(recovered.to(expected.units).m, expected.m, rtol=1e-10)
+
+        # A modified <J.B> must give an F' that reproduces it when pushed back
+        # through the Grad-Shafranov relation
+        modified = 1.5 * redl.JdotB
+        modified_Fprime = redl.get_Fprime_from_total_current(modified)
+
+        _, F, _, mu0_dpdpsi, mu0 = redl._get_grad_shafranov_terms()
+        rebuilt = (modified_Fprime * redl.B2_fsa + F * mu0_dpdpsi) / mu0
+
+        assert_allclose(rebuilt.to(modified.units).m, modified.m, rtol=1e-10)
+
+        # Changing the current really does change F', so the round trip above
+        # is not passing simply because the two inputs coincide
+        assert not np.isclose(
+            modified_Fprime.to(expected.units).m, recovered.to(expected.units).m
+        )

--- a/tests/diagnostics/test_neoclassical.py
+++ b/tests/diagnostics/test_neoclassical.py
@@ -1,8 +1,13 @@
 import netCDF4 as nc
+import numpy as np
 from numpy.testing import assert_allclose
 
 from pyrokinetics import Pyro, template_dir
-from pyrokinetics.diagnostics.neoclassical import Redl2021, Sauter1999
+from pyrokinetics.diagnostics.neoclassical import (
+    Redl2021,
+    Sauter1999,
+    integrate_toroidal_current,
+)
 from pyrokinetics.units import ureg as units
 
 
@@ -63,3 +68,108 @@ def test_bootstrap_current():
     assert_allclose(sauter_jbsdotb_b2.m, scene_jbsdotb_b2.m, rtol=15e-2)
     assert_allclose(redl_jtotdotb_b2.m, scene_jtotdotb_b2.m, rtol=1e-2)
     assert_allclose(sauter_jtotdotb_b2.m, scene_jtotdotb_b2.m, rtol=1e-2)
+
+
+def test_toroidal_current():
+    """
+    Compare the toroidal current density and its decomposition against SCENE.
+
+    SCENE's ``J_tor`` is the flux-surface averaged toroidal current density
+    ``<J_phi>``, and is built from the parallel (bootstrap + external) currents
+    only, i.e. it excludes the Pfirsch-Schlueter and diamagnetic contributions.
+    """
+
+    scene_cdf = template_dir / "scene.cdf"
+    scene_eqdsk = template_dir / "step.geqdsk"
+
+    scene_data = nc.Dataset(scene_cdf)
+    indices = slice(10, -10, 2)
+    scene_psin = scene_data["rho_psi"][indices] ** 2
+
+    j_units = units.ampere / units.meter**2
+    scene_jtor = scene_data["J_tor"][indices].data * j_units
+    scene_jbs_tor = scene_data["Jbs_tor"][indices].data * j_units
+    scene_zeff = scene_data["zeff"][indices].data * units.elementary_charge
+
+    pyro = Pyro(
+        eq_file=scene_eqdsk,
+        eq_type="GEQDSK",
+        kinetics_file=scene_cdf,
+        kinetics_type="SCENE",
+    )
+
+    parallel_jtor = scene_jtor * 0.0
+    bs_jtor = scene_jtor * 0.0
+
+    for i, psi_n in enumerate(scene_psin):
+        try:
+            pyro.load_local(psi_n=psi_n, local_geometry="MXH")
+        except Exception:
+            continue
+
+        pyro.local_species.zeff = scene_zeff[i]
+
+        redl = Redl2021(pyro)
+
+        # SCENE's J_tor omits the Pfirsch-Schlueter + diamagnetic part
+        parallel_jtor[i] = (redl.Jphi_fsa - redl.Jphi_psdia_fsa).to(j_units)
+        bs_jtor[i] = redl.Jphi_bs_fsa.to(j_units)
+
+        # The decomposition must sum back to the total, for both definitions
+        assert_allclose(
+            (redl.Jphi_bs_fsa + redl.Jphi_ext_fsa + redl.Jphi_psdia_fsa).m,
+            redl.Jphi_fsa.m,
+            rtol=1e-10,
+        )
+        assert_allclose(
+            (redl.Jphi_bs_eff + redl.Jphi_ext_eff + redl.Jphi_psdia_eff).m,
+            redl.Jphi_eff.m,
+            rtol=1e-10,
+        )
+
+        # The flux-surface average of the local J_phi(theta) profile must equal
+        # the directly computed <J_phi>
+        assert_allclose(
+            pyro.metric_terms.flux_surface_average(redl.Jphi).m,
+            redl.Jphi_fsa.m,
+            rtol=1e-8,
+        )
+
+        # Enclosed plasma current shares the sign convention of J_phi
+        assert np.sign(redl.Ip.m) == np.sign(redl.Jphi_fsa.m)
+
+    assert_allclose(parallel_jtor.m, scene_jtor.m, rtol=2e-2)
+    assert_allclose(bs_jtor.m, scene_jbs_tor.m, rtol=6e-2)
+
+
+def test_integrate_toroidal_current():
+    """
+    The radially integrated current components must sum to the total, and that
+    total must agree with the enclosed current obtained independently from
+    Ampere's law on each surface.
+    """
+
+    pyro = Pyro(
+        eq_file=template_dir / "step.geqdsk",
+        eq_type="GEQDSK",
+        kinetics_file=template_dir / "scene.cdf",
+        kinetics_type="SCENE",
+    )
+
+    result = integrate_toroidal_current(
+        pyro, np.linspace(0.02, 0.9, 25), local_geometry="MXH"
+    )
+
+    components = result["Ip_bs"] + result["Ip_ext"] + result["Ip_psdia"]
+    assert_allclose(components.m, result["Ip"].m, rtol=1e-10)
+
+    # Skip the innermost surfaces, where the near-axis contribution assumed by the
+    # integration dominates
+    assert_allclose(
+        result["Ip"][5:].to("MA").m,
+        result["Ip_ampere"][5:].to("MA").m,
+        rtol=1e-2,
+    )
+
+    # Integrating outwards, the enclosed current grows monotonically in magnitude
+    assert np.all(np.diff(np.abs(result["Ip"].m)) > 0)

--- a/tests/local_geometry/test_metric_terms.py
+++ b/tests/local_geometry/test_metric_terms.py
@@ -139,11 +139,17 @@ def test_flux_surface_average():
     assert np.min(metric_terms.R) < R_fsa < np.max(metric_terms.R)
 
 
-def test_dVdr_matches_local_geometry():
-    """MetricTerms.dVdr agrees with the LocalGeometry quad-based calculation"""
+@pytest.mark.parametrize("nturns", [1, 3, 5])
+def test_dVdr_matches_local_geometry(nturns):
+    """
+    MetricTerms.dVdr agrees with the LocalGeometry quad-based calculation, and is
+    independent of how many poloidal turns the theta grid spans
+    """
     pyro = Pyro(gk_file=template_dir / "input.cgyro", gk_code="CGYRO")
     local_geometry = pyro.local_geometry
-    metric_terms = MetricTerms(local_geometry, ntheta=1024)
+
+    theta = np.linspace(-nturns * np.pi, nturns * np.pi, 1024 * nturns)
+    metric_terms = MetricTerms(local_geometry, theta=theta)
 
     _, _, dVdr = local_geometry.get_flux_surface_area_volume_derivatives()
 

--- a/tests/local_geometry/test_metric_terms.py
+++ b/tests/local_geometry/test_metric_terms.py
@@ -125,6 +125,31 @@ def test_metric_terms_input():
     assert isinstance(metric_terms, MetricTerms)
 
 
+def test_flux_surface_average():
+    """The flux surface average of unity is unity, and units are preserved"""
+    pyro = Pyro(gk_file=template_dir / "input.cgyro", gk_code="CGYRO")
+    metric_terms = MetricTerms(pyro.local_geometry, ntheta=512)
+
+    ones = np.ones(len(metric_terms.regulartheta))
+    np.testing.assert_allclose(metric_terms.flux_surface_average(ones), 1.0, rtol=1e-10)
+
+    # A quantity carrying units keeps them
+    R_fsa = metric_terms.flux_surface_average(metric_terms.R)
+    assert R_fsa.units == metric_terms.R.units
+    assert np.min(metric_terms.R) < R_fsa < np.max(metric_terms.R)
+
+
+def test_dVdr_matches_local_geometry():
+    """MetricTerms.dVdr agrees with the LocalGeometry quad-based calculation"""
+    pyro = Pyro(gk_file=template_dir / "input.cgyro", gk_code="CGYRO")
+    local_geometry = pyro.local_geometry
+    metric_terms = MetricTerms(local_geometry, ntheta=1024)
+
+    _, _, dVdr = local_geometry.get_flux_surface_area_volume_derivatives()
+
+    np.testing.assert_allclose(metric_terms.dVdr.m, dVdr.m, rtol=1e-3)
+
+
 # Scan geometry parameters
 @pytest.mark.parametrize(
     "q,betaprime,shat",

--- a/tests/test_local_species.py
+++ b/tests/test_local_species.py
@@ -217,6 +217,110 @@ def test_merge_update_zeff_isotopes(simple_local_species: LocalSpecies):
     np.testing.assert_allclose(simple_local_species.zeff.magnitude, 8.0 / 3.0)
 
 
+def _collision_frequency(z: float, dens: float, temp: float, mass: float) -> float:
+    """Standard like-species scaling, nu ~ z^4 n / (T^3/2 sqrt(m)).
+
+    Written out independently of ``merge_species`` so the tests below check the
+    physics rather than the way the implementation groups its factors.
+    """
+    return z**4 * dens / (temp**1.5 * np.sqrt(mass))
+
+
+@pytest.mark.parametrize(
+    "keep_z,keep_mass,new_z,new_dens,new_mass",
+    (
+        # keep_z: density absorbs all the merged charge, z and mass are held
+        (True, True, 1.0, 1.0, 1.0),
+        # otherwise density is the particle sum, z the number-weighted mean charge,
+        # and mass the density-weighted mean
+        (False, False, 18.0 / 13.0, 13.0 / 18.0, 109.0 / 78.0),
+    ),
+)
+def test_merge_update_nu(
+    simple_local_species: LocalSpecies,
+    keep_z: bool,
+    keep_mass: bool,
+    new_z: float,
+    new_dens: float,
+    new_mass: float,
+):
+    """``update_nu`` rescales nu to the merged charge, density and mass."""
+    deuterium = simple_local_species["deuterium"]
+    old_nu = deuterium.nu.magnitude
+    old = _collision_frequency(
+        deuterium.z.magnitude,
+        deuterium.dens.magnitude,
+        deuterium.temp.magnitude,
+        deuterium.mass.magnitude,
+    )
+    # temp is untouched by a merge
+    temp = deuterium.temp.magnitude
+
+    simple_local_species.merge_species(
+        "deuterium",
+        ["carbon12", "carbon13"],
+        keep_base_species_z=keep_z,
+        keep_base_species_mass=keep_mass,
+        update_nu=True,
+    )
+
+    merged = simple_local_species["deuterium"]
+    # the merge produced the charge/density/mass the scaling is built from
+    np.testing.assert_allclose(merged.z.magnitude, new_z)
+    np.testing.assert_allclose(merged.dens.magnitude, new_dens)
+    np.testing.assert_allclose(merged.mass.magnitude, new_mass)
+
+    expected = old_nu * _collision_frequency(new_z, new_dens, temp, new_mass) / old
+    np.testing.assert_allclose(merged.nu.magnitude, expected)
+
+
+def test_merge_leaves_nu_stale_by_default(simple_local_species: LocalSpecies):
+    """Without ``update_nu`` the merge leaves a nu belonging to the old density."""
+    old_nu = simple_local_species["deuterium"].nu.magnitude
+    old_dens = simple_local_species["deuterium"].dens.magnitude
+
+    simple_local_species.merge_species(
+        "deuterium", ["carbon12", "carbon13"], keep_base_species_z=True
+    )
+
+    # density has changed but nu has not, so the two are no longer consistent
+    assert simple_local_species["deuterium"].dens.magnitude != old_dens
+    np.testing.assert_allclose(simple_local_species["deuterium"].nu.magnitude, old_nu)
+
+
+def test_merge_update_nu_doubles_for_identical_species(
+    simple_local_species: LocalSpecies,
+):
+    """Merging two identical ion populations doubles the collision frequency."""
+    # Rebuild as a quasineutral two-deuterium plasma so the merge is a pure
+    # doubling of density with charge, mass and temperature all unchanged.
+    simple_local_species.remove_species("carbon12", "carbon13")
+    simple_local_species.add_species(
+        name="deuterium_copy",
+        species_data=_species_data(mass=1.0, z=1.0, dens=2.0 / 3.0, inverse_ln=3.0),
+    )
+    electron = simple_local_species["electron"]
+    electron.dens = 4.0 / 3.0 * electron.dens.units
+    electron.inverse_ln = 3.0 * electron.inverse_ln.units
+    assert simple_local_species.check_quasineutrality(tol=1e-8)
+
+    old_nu = simple_local_species["deuterium"].nu.magnitude
+    simple_local_species.merge_species(
+        "deuterium",
+        ["deuterium_copy"],
+        keep_base_species_z=True,
+        keep_base_species_mass=True,
+        update_nu=True,
+    )
+
+    np.testing.assert_allclose(
+        simple_local_species["deuterium"].dens.magnitude, 4.0 / 3
+    )
+    np.testing.assert_allclose(
+        simple_local_species["deuterium"].nu.magnitude, 2.0 * old_nu
+    )
+
+
 def test_normalisation():
     """Test that a local species can be renormalised with simulation units."""
     pyro = pk.Pyro(gk_file=pk.gk_templates["GS2"])

--- a/tests/test_local_species.py
+++ b/tests/test_local_species.py
@@ -167,6 +167,56 @@ def test_merge_fuel_impurity(
         )
 
 
+@pytest.mark.parametrize(
+    "keep_z,expected_zeff",
+    (
+        # After merging every ion into one, zeff = n_i Z_i^2 / n_e, and
+        # quasineutrality gives n_i Z_i = n_e, so zeff collapses to the merged Z.
+        (True, 1.0),
+        (False, 18.0 / 13.0),
+    ),
+)
+def test_merge_update_zeff(
+    simple_local_species: LocalSpecies, keep_z: bool, expected_zeff: float
+):
+    """``update_zeff`` recalculates zeff from the species left after the merge."""
+    simple_local_species.set_zeff()
+    np.testing.assert_allclose(simple_local_species.zeff.magnitude, 8.0 / 3.0)
+
+    simple_local_species.merge_species(
+        "deuterium",
+        ["carbon12", "carbon13"],
+        keep_base_species_z=keep_z,
+        update_zeff=True,
+    )
+
+    np.testing.assert_allclose(simple_local_species.zeff.magnitude, expected_zeff)
+    np.testing.assert_allclose(
+        simple_local_species["deuterium"].z.magnitude, expected_zeff
+    )
+
+
+def test_merge_leaves_zeff_stale_by_default(simple_local_species: LocalSpecies):
+    """Without ``update_zeff`` the cached multi-species zeff survives the merge."""
+    simple_local_species.set_zeff()
+    simple_local_species.merge_species(
+        "deuterium", ["carbon12", "carbon13"], keep_base_species_z=True
+    )
+    # Only hydrogenic species remain, but zeff still describes the original plasma
+    assert simple_local_species.names == ["electron", "deuterium"]
+    np.testing.assert_allclose(simple_local_species["deuterium"].z.magnitude, 1.0)
+    np.testing.assert_allclose(simple_local_species.zeff.magnitude, 8.0 / 3.0)
+
+
+def test_merge_update_zeff_isotopes(simple_local_species: LocalSpecies):
+    """Merging equal-charge isotopes conserves sum(n Z^2), so zeff is unchanged."""
+    simple_local_species.set_zeff()
+    simple_local_species.merge_species(
+        "carbon12", ["carbon13"], keep_base_species_z=True, update_zeff=True
+    )
+    np.testing.assert_allclose(simple_local_species.zeff.magnitude, 8.0 / 3.0)
+
+
 def test_normalisation():
     """Test that a local species can be renormalised with simulation units."""
     pyro = pk.Pyro(gk_file=pk.gk_templates["GS2"])


### PR DESCRIPTION
In `neoclassical.py` it calculates total current and boot strap. I added calculations of toroidal current for comparison with some other code outputs like JETTO. So now it has $J_\phi$, $\langle J_\phi \rangle$ and $J_\phi^{eff} \equiv \frac{1}{2pi\rho}\frac{dI_p}{d \rho}$, where $I_p$ is the total plasma current in closed within minor radius $\rho$ and each of them split into bootstrap, Pfirsch-Schlüter + diamagnetic and the rest (external and ohmic).